### PR TITLE
Added docker-compose.yml example

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,5 @@
+CONF_updateInterval=300
+CONF_babelLocale='de'
+CONF_mqtt='@json {"broker": "mqtt", "username": "", "password": ""}'
+CONF_volvoData='@json {"username": "", "password": "", "vin": "",   "vccapikey": ""}'
+TZ='Europe/Berlin'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 venv
 src/settings.dev.json
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+services:
+  app:
+    build: .
+    env_file:
+      - .env
+    #    environment:
+    #      CONF_updateInterval: 300
+    #      CONF_babelLocale: 'de'
+    #      CONF_mqtt: '@json {"broker": "mqtt", "username": "", "password": ""}'
+    #      CONF_volvoData: '@json {"username": "", "password": "", "vin": "",   "vccapikey": ""}'
+    #      TZ: 'Europe/Berlin'
+    links:
+      - mqtt
+    depends_on:
+      - mqtt
+
+  mqtt:
+    container_name: mqtt
+    image: eclipse-mosquitto
+    expose:
+      - 1883
+    command: [ "/usr/sbin/mosquitto", "-c", "/mosquitto-no-auth.conf" ]
+


### PR DESCRIPTION
I've added a simple docker-compose example for easy testing.
copy `.env.dist` to `.env`. Or load env vars from `docker-compose.yml` file instead of `.env` file.