### PR TITLE
Add bulb warning status + calculate estimated efficiency (BEV only)

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.7.8
+### 🐛 Bug Fixes:
+
+- Fix "Estimated Charging Finish Time" Sensor  
+
 ## v1.7.7
 ### 🚀 Features:
 

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.7.7
+### 🚀 Features:
+
+- Added long term statistics for some sensors #68. Thanks to @bogdanbujdea!
+- Automatic redact sensitive data from debug log
+
 ## v1.7.6
 ### 🚀 Features:
 

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 - Added long term statistics for some sensors #68. Thanks to @bogdanbujdea!
 - Automatic redact sensitive data from debug log
+- Perpare for scheduler option (not yet ready)
 
 ## v1.7.6
 ### 🚀 Features:

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -1,6 +1,6 @@
 name: "Volvo2Mqtt"
 description: "Volvo AAOS MQTT bridge"
-version: "1.7.7"
+version: "1.7.8"
 slug: "volvo2mqtt"
 init: false
 url: "https://github.com/Dielee/volvo2mqtt"

--- a/src/const.py
+++ b/src/const.py
@@ -20,6 +20,7 @@ BATTERY_CHARGE_STATE_URL = "https://api.volvocars.com/connected-vehicle/v2/vehic
 FUEL_STATE_URL = "https://api.volvocars.com/connected-vehicle/v2/vehicles/{0}/fuel"
 STATISTICS_URL = "https://api.volvocars.com/connected-vehicle/v2/vehicles/{0}/statistics"
 ENGINE_DIAGNOSTICS_URL = "https://api.volvocars.com/connected-vehicle/v2/vehicles/{0}/engine"
+VEHICLE_DIAGNOSTICS_URL = "https://api.volvocars.com/connected-vehicle/v2/vehicles/{0}/diagnostics"
 
 units = {
             "en_GB": {
@@ -109,5 +110,11 @@ supported_entities = [
                         {"name": "Fuel Level", "domain": "sensor", "id": "fuel_level", "unit": "liters", "icon": "fuel", "url": FUEL_STATE_URL, "state_class": "measurement"},
                         {"name": "Average Fuel Consumption", "domain": "sensor", "id": "average_fuel_consumption", "unit": "liters", "icon": "fuel", "url": STATISTICS_URL},
                         {"name": "Distance to Empty", "domain": "sensor", "id": "distance_to_empty", "unit": "km" if not units.get(settings["babelLocale"]) else units[settings["babelLocale"]]["distance_to_empty"]["unit"], "icon": "map-marker-distance", "url": STATISTICS_URL, "state_class": "measurement"},
-                        {"name": "Average Speed", "domain": "sensor", "id": "average_speed", "unit": "km/h" if not units.get(settings["babelLocale"]) else units[settings["babelLocale"]]["average_speed"]["unit"], "icon": "speedometer", "url": STATISTICS_URL, "state_class": "measurement"}
+                        {"name": "Average Speed", "domain": "sensor", "id": "average_speed", "unit": "km/h" if not units.get(settings["babelLocale"]) else units[settings["babelLocale"]]["average_speed"]["unit"], "icon": "speedometer", "url": STATISTICS_URL, "state_class": "measurement"},
+                        {"name": "Hours to Service", "domain": "sensor", "id": "hours_to_service", "unit": "hour", "icon": "wrench-clock", "url": VEHICLE_DIAGNOSTICS_URL, "state_class": "measurement"},
+                        {"name": "Distance to Service", "domain": "sensor", "id": "km_to_service", "unit": "km" if not units.get(settings["babelLocale"]) else units[settings["babelLocale"]]["distance_to_service"]["unit"], "icon": "wrench-clock", "url": VEHICLE_DIAGNOSTICS_URL, "state_class": "measurement"},
+                        {"name": "Months to Service", "domain": "sensor", "id": "months_to_service", "unit": "month", "icon": "wrench-clock", "url": VEHICLE_DIAGNOSTICS_URL, "state_class": "measurement"},
+                        {"name": "Service warning status", "domain": "sensor", "id": "service_warning_status", "icon": "alert-outline", "url": VEHICLE_DIAGNOSTICS_URL},
+                        {"name": "Service warning trigger", "domain": "sensor", "id": "service_warning_trigger", "icon": "alert-outline", "url": VEHICLE_DIAGNOSTICS_URL}
+
 ]

--- a/src/const.py
+++ b/src/const.py
@@ -111,10 +111,9 @@ supported_entities = [
                         {"name": "Average Fuel Consumption", "domain": "sensor", "id": "average_fuel_consumption", "unit": "liters", "icon": "fuel", "url": STATISTICS_URL},
                         {"name": "Distance to Empty", "domain": "sensor", "id": "distance_to_empty", "unit": "km" if not units.get(settings["babelLocale"]) else units[settings["babelLocale"]]["distance_to_empty"]["unit"], "icon": "map-marker-distance", "url": STATISTICS_URL, "state_class": "measurement"},
                         {"name": "Average Speed", "domain": "sensor", "id": "average_speed", "unit": "km/h" if not units.get(settings["babelLocale"]) else units[settings["babelLocale"]]["average_speed"]["unit"], "icon": "speedometer", "url": STATISTICS_URL, "state_class": "measurement"},
-                        {"name": "Hours to Service", "domain": "sensor", "id": "hours_to_service", "unit": "hour", "icon": "wrench-clock", "url": VEHICLE_DIAGNOSTICS_URL, "state_class": "measurement"},
-                        {"name": "Distance to Service", "domain": "sensor", "id": "km_to_service", "unit": "km" if not units.get(settings["babelLocale"]) else units[settings["babelLocale"]]["distance_to_service"]["unit"], "icon": "wrench-clock", "url": VEHICLE_DIAGNOSTICS_URL, "state_class": "measurement"},
-                        {"name": "Months to Service", "domain": "sensor", "id": "months_to_service", "unit": "month", "icon": "wrench-clock", "url": VEHICLE_DIAGNOSTICS_URL, "state_class": "measurement"},
+                        {"name": "Hours to Service", "domain": "sensor", "id": "hours_to_service", "unit": "hour", "icon": "wrench-clock", "url": VEHICLE_DIAGNOSTICS_URL},
+                        {"name": "Distance to Service", "domain": "sensor", "id": "km_to_service", "unit": "km" if not units.get(settings["babelLocale"]) else units[settings["babelLocale"]]["distance_to_service"]["unit"], "icon": "wrench-clock", "url": VEHICLE_DIAGNOSTICS_URL},
+                        {"name": "Months to Service", "domain": "sensor", "id": "months_to_service", "unit": "month", "icon": "wrench-clock", "url": VEHICLE_DIAGNOSTICS_URL},
                         {"name": "Service warning status", "domain": "sensor", "id": "service_warning_status", "icon": "alert-outline", "url": VEHICLE_DIAGNOSTICS_URL},
                         {"name": "Service warning trigger", "domain": "sensor", "id": "service_warning_trigger", "icon": "alert-outline", "url": VEHICLE_DIAGNOSTICS_URL}
-
 ]

--- a/src/const.py
+++ b/src/const.py
@@ -1,6 +1,6 @@
 from config import settings
 
-VERSION = "v1.7.7"
+VERSION = "v1.7.8"
 
 OAUTH_URL = "https://volvoid.eu.volvocars.com/as/token.oauth2"
 VEHICLES_URL = "https://api.volvocars.com/connected-vehicle/v1/vehicles"
@@ -80,7 +80,7 @@ supported_entities = [
                         {"name": "Estimated Charging Time", "domain": "sensor", "id": "estimated_charging_time", "unit": "minutes", "icon": "timer-sync-outline", "url": RECHARGE_STATE_URL, "state_class": "measurement"},
                         {"name": "Charging System Status", "domain": "sensor", "id": "charging_system_status", "icon": "ev-station", "url": RECHARGE_STATE_URL},
                         {"name": "Charging Connection Status", "domain": "sensor", "id": "charging_connection_status", "icon": "ev-plug-ccs2", "url": RECHARGE_STATE_URL},
-                        {"name": "Estimated Charging Finish Time", "domain": "sensor", "id": "estimated_charging_finish_time", "icon": "timer-sync-outline", "url": RECHARGE_STATE_URL, "state_class": "measurement"},
+                        {"name": "Estimated Charging Finish Time", "domain": "sensor", "id": "estimated_charging_finish_time", "icon": "timer-sync-outline", "url": RECHARGE_STATE_URL},
                         {"name": "Odometer", "domain": "sensor", "id": "odometer", "unit": "km" if not units.get(settings["babelLocale"]) else units[settings["babelLocale"]]["odometer"]["unit"], "icon": "counter", "url": ODOMETER_STATE_URL, "state_class":"total_increasing"},
                         {"name": "Last Data Update", "domain": "sensor", "id": "last_data_update", "icon": "timer", "url": ""},
                         {"name": "Active schedules", "domain": "sensor", "id": "active_schedules", "icon": "timer", "url": ""},

--- a/src/volvo.py
+++ b/src/volvo.py
@@ -436,5 +436,19 @@ def parse_api_data(data, sensor_id=None):
             if distance_to_empty > 0:
                 return util.convert_metric_values(data["distanceToEmpty"]["value"])
         return None
+    elif sensor_id == "hours_to_service":
+        return data["engineHoursToService"]["value"] if util.keys_exists(data, "engineHoursToService") else None
+    elif sensor_id == "km_to_service":
+        if util.keys_exists(data, "kmToService"):
+            km_to_service = int(data["kmToService"]["value"])
+            if km_to_service > 0:
+                return util.convert_metric_values(data["kmToService"]["value"])
+        return None
+    elif sensor_id == "months_to_service":
+        return data["monthsToService"]["value"] if util.keys_exists(data, "monthsToService") else None
+    elif sensor_id == "service_warning_status":
+        return data["serviceWarningStatus"]["value"] if util.keys_exists(data, "serviceWarningStatus") else None
+    elif sensor_id == "service_warning_trigger":
+        return data["serviceWarningTrigger"]["value"] if util.keys_exists(data, "serviceWarningTrigger") else None
     else:
         return None


### PR DESCRIPTION
Unfortunately I was not able to create two separate PRs. Sorry for this.

My suggested additions:
* implement 'warnings' API. At this moment for bulb failure only. I was not able to test a failure. My interpretation is that the field becomes available as soon there is a failure. For my car (C40) the API responded, however with only basic data. Therefor it now response 'none' of there is not data
* Estimated efficiency: the electric range is based on battery capacity and recent energy consumption. This value calculates the estimated efficiency the car is using to calculate the range. Added also to long term statistics. To calculate this value the capacity of the battery is needed (eg. 67). Added it to the configuration.