### PR TITLE
Allow MQTT client name configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Here is what every option means:
 | `CONF_updateInterval`     | `int`     |                                       | **required** | Update intervall in seconds.                                     |
 | `CONF_babelLocale`        | `string`  |                                       | **required** | Select your country from this [list](https://www.ibm.com/docs/en/radfws/9.7?topic=overview-locales-code-pages-supported). "Locale name" is the column you need!                                        |
 | `CONF_mqtt`               | `json`    | `broker`                              | **required** | Your MQTT Broker IP. Eg. 192.168.0.5.
+| `CONF_mqtt`               | `json`    | `mqtt_client`                              | volvoAAOS2mqtt | Name of the MQTT client used on connection. Setting this to an alternate string can be used to run multiple instances of volvo2mqtt.
 | `CONF_mqtt`               | `json`    | `port`                                | 1883         | Your MQTT Broker Port. If no value is given, port 1883 will be used.  |
 | `CONF_mqtt`               | `json`    | `username`                            | optional     | MQTT Username for your broker.
 | `CONF_mqtt`               | `json`    | `password`                            | optional     | MQTT Password for your broker.

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -18,6 +18,7 @@ options:
   mqtt:
     broker: "auto_broker"
     port: "auto_port"
+    mqtt_client: "volvoAAOS2mqtt"
     username: "auto_user"
     password: "auto_password"
   volvoData:
@@ -36,6 +37,7 @@ schema:
   debug: bool
   mqtt:
     broker: str
+    mqtt_client: str
     port: str
     username: str?
     password: str?

--- a/src/mqtt.py
+++ b/src/mqtt.py
@@ -23,7 +23,8 @@ active_schedules = {}
 
 
 def connect():
-    client = mqtt.Client("volvoAAOS2mqtt")
+    logging.info("Connecting to MQTT with client name %s" , settings["mqtt"]["mqtt_client"])
+    client = mqtt.Client(settings["mqtt"]["mqtt_client"])
     client.will_set(availability_topic, "offline", 0, False)
     if settings["mqtt"]["username"] and settings["mqtt"]["password"]:
         client.username_pw_set(settings["mqtt"]["username"], settings["mqtt"]["password"])

--- a/src/settings.json
+++ b/src/settings.json
@@ -3,6 +3,7 @@
   "babelLocale": "de",
   "TZ": "Europe/Berlin",
   "mqtt": {
+    "mqtt_client" : "volvoAAOS2mqtt",
     "broker": "",
     "port": 1883,
     "username": "",


### PR DESCRIPTION
Accept MQTT client name configuration to allow for multiple instances.

Fixes #93