### PR TITLE
Add "Battery Capacity" sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Please let me know if your car works with this addon so I can expand the list!<b
 - Lock/unlock car
 - Start/stop climate
 - Sensor "Battery Charge Level"
+- Sensor "Battery Capacity"
 - Sensor "Electric Range"
 - Sensor "Charging System Status"
 - Sensor "Charging Connection Status" (partly broken since 2.10 car update)

--- a/src/const.py
+++ b/src/const.py
@@ -91,6 +91,7 @@ icon_states = {
 supported_entities = [
                         {"name": "Battery Charge Level", "domain": "sensor", "device_class": "battery", "id": "battery_charge_level", "unit": "%", "icon": "car-battery", "url": RECHARGE_STATE_URL, "state_class": "measurement"},
                         {"name": "Battery Charge Level", "domain": "sensor", "device_class": "battery", "id": "battery_charge_level", "unit": "%", "icon": "car-battery", "url": FUEL_BATTERY_STATE_URL, "state_class": "measurement"},
+                        {"name": "Battery Capacity", "domain": "sensor", "device_class": "energy_storage", "id": "battery_capacity", "unit": ENERGY_KILO_WATT_HOUR, "icon": "car-battery", "url": VEHICLE_DETAILS_URL, "state_class": "measurement"},
                         {"name": "Electric Range", "domain": "sensor", "id": "electric_range", "unit": LENGTH_KILOMETERS if not units.get(settings["babelLocale"]) else units[settings["babelLocale"]]["electric_range"]["unit"], "icon": "map-marker-distance", "url": RECHARGE_STATE_URL, "state_class": "measurement"},
                         {"name": "Estimated Charging Time", "domain": "sensor", "id": "estimated_charging_time", "unit": TIME_MINUTES, "icon": "timer-sync-outline", "url": RECHARGE_STATE_URL, "state_class": "measurement"},
                         {"name": "Charging System Status", "domain": "sensor", "id": "charging_system_status", "icon": "ev-station", "url": RECHARGE_STATE_URL},

--- a/src/volvo.py
+++ b/src/volvo.py
@@ -443,6 +443,8 @@ def parse_api_data(data, sensor_id=None):
 
     if sensor_id == "battery_charge_level":
         return data["batteryChargeLevel"]["value"] if util.keys_exists(data, "batteryChargeLevel") else None
+    elif sensor_id == "battery_capacity":
+        return data["batteryCapacityKWH"] if util.keys_exists(data, "batteryCapacityKWH") else None
     elif sensor_id == "electric_range":
         return util.convert_metric_values(data["electricRange"]["value"]) \
             if util.keys_exists(data, "electricRange") else None


### PR DESCRIPTION
I noticed the [get vehicle details endpoint](https://developer.volvocars.com/apis/connected-vehicle/v2/endpoints/vehicle/#get-vehicle-details) provides the battery capacity for electric/hybrid Volvo's. This might be useful in personal calculations/automations.

<img width="604" alt="battery_capacity" src="https://github.com/Dielee/volvo2mqtt/assets/13830735/49408306-2dab-4e95-8444-7f1caebabb54">
