### PR TITLE
Handle boundary condition when selecting battery icon

### DIFF
--- a/src/const.py
+++ b/src/const.py
@@ -75,17 +75,17 @@ icon_states = {
     "door_rear_right": {"ON": "car-door", "OFF": "car-door-lock"},
     "engine_state": {"ON": "engine-outline", "OFF": "engine-off-outline"},
     "battery_charge_level": [
-                    {"from": 100, "to": 100, "icon": "battery"},
-                    {"from": 99, "to": 90, "icon": "battery-90"},
-                    {"from": 89, "to": 80, "icon": "battery-80"},
-                    {"from": 79, "to": 70, "icon": "battery-70"},
-                    {"from": 69, "to": 60, "icon": "battery-60"},
-                    {"from": 59, "to": 50, "icon": "battery-50"},
-                    {"from": 49, "to": 40, "icon": "battery-40"},
-                    {"from": 39, "to": 30, "icon": "battery-30"},
-                    {"from": 29, "to": 20, "icon": "battery-20"},
-                    {"from": 19, "to": 10, "icon": "battery-10"},
-                    {"from": 9, "to": 0, "icon": "battery-alert-variant-outline"},
+                    {"from": float('inf'), "to": 100, "icon": "battery"},
+                    {"from": 100, "to": 90, "icon": "battery-90"},
+                    {"from": 90, "to": 80, "icon": "battery-80"},
+                    {"from": 80, "to": 70, "icon": "battery-70"},
+                    {"from": 70, "to": 60, "icon": "battery-60"},
+                    {"from": 60, "to": 50, "icon": "battery-50"},
+                    {"from": 50, "to": 40, "icon": "battery-40"},
+                    {"from": 40, "to": 30, "icon": "battery-30"},
+                    {"from": 30, "to": 20, "icon": "battery-20"},
+                    {"from": 20, "to": 10, "icon": "battery-10"},
+                    {"from": 10, "to": 0, "icon": "battery-alert-variant-outline"},
     ]
 }
 

--- a/src/util.py
+++ b/src/util.py
@@ -57,7 +57,7 @@ def save_to_json(data, token_path):
 def get_icon_between(icon_list, state):
     icon = None
     for s in icon_list:
-        if s["to"] <= state <= s["from"]:
+        if s["to"] <= state < s["from"]:
             icon = s["icon"]
     return icon
 


### PR DESCRIPTION
We need to be able to handle floating point numbers right on the boundary between two icons. This means our from..to configurations must perfectly align at each end, and the algorithm to select those must _not_ be both less-than-or-equal (<=) AND more-than-or-equal (>=).

Here are the outputs in a shell after this change:

```
  >>> get_icon_between(icon_states["battery_charge_level"], 0)
  'battery-alert-variant-outline'
  >>> get_icon_between(icon_states["battery_charge_level"], 9.9)
  'battery-alert-variant-outline'
  >>> get_icon_between(icon_states["battery_charge_level"], 10)
  'battery-10'
  >>> get_icon_between(icon_states["battery_charge_level"], 39)
  'battery-30'
  >>> get_icon_between(icon_states["battery_charge_level"], 39.9)
  'battery-30'
  >>> get_icon_between(icon_states["battery_charge_level"], 39.9999)
  'battery-30'
  >>> get_icon_between(icon_states["battery_charge_level"], 40)
  'battery-40'
  >>> get_icon_between(icon_states["battery_charge_level"], 99.99)
  'battery-90'
  >>> get_icon_between(icon_states["battery_charge_level"], 100)
  'battery'
  >>> get_icon_between(icon_states["battery_charge_level"], 101)
  'battery'
```

Fixes https://github.com/Dielee/volvo2mqtt/issues/230