### PR TITLE
handle missing refresh_token key in token file

### DIFF
--- a/src/volvo.py
+++ b/src/volvo.py
@@ -48,6 +48,10 @@ def authorize(renew_tokenfile=False):
             logging.warning("Detected corrupted token file, restarting auth process")
             authorize(True)
             return
+        except KeyError:
+            logging.warning("Token file missing refresh_token, restarting auth process")
+            authorize(True)
+            return
     else:
         logging.info("Starting login with OTP")
         auth_session = requests.session()


### PR DESCRIPTION
Fixes the issue mentioned in #296 so the user doesn't have to manually delete the .token file.