### PR TITLE
Fix AttributeError: paho-mqtt < 2.0 backward compatibility

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.13.4
+
+### 🐛 Bug Fixes:
+
+- Fix `AttributeError: module 'paho.mqtt.client' has no attribute 'CallbackAPIVersion'` when paho-mqtt < 2.0 is installed
+
 ## v1.13.3
 
 ### 🐛 Bug Fixes:

--- a/src/mqtt.py
+++ b/src/mqtt.py
@@ -25,9 +25,13 @@ active_schedules = {}
 otp_code = None
 
 def connect():
-    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, "volvoAAOS2mqtt") \
-                if os.environ.get("IS_HA_ADDON") \
-                else mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, "volvoAAOS2mqtt_" + settings.volvoData["username"].replace("+", ""))
+    client_id = "volvoAAOS2mqtt" if os.environ.get("IS_HA_ADDON") \
+        else "volvoAAOS2mqtt_" + settings.volvoData["username"].replace("+", "")
+    try:
+        client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, client_id)
+    except AttributeError:
+        # paho-mqtt < 2.0 does not have CallbackAPIVersion
+        client = mqtt.Client(client_id)
 
     if "logging" in settings["mqtt"] and settings["mqtt"]["logging"]:
         mqtt_logger = logging.getLogger("mqtt")


### PR DESCRIPTION
## Problem

After the v1.13.3 pypi package bump, users with cached Docker layers still running `paho-mqtt~=1.6.1` crash immediately on startup with:

```
AttributeError: module 'paho.mqtt.client' has no attribute 'CallbackAPIVersion'
```

This happens because `mqtt.CallbackAPIVersion` was introduced in paho-mqtt 2.0. If the Docker build cache serves a stale image layer with paho-mqtt 1.x, the addon cannot start at all.

## Fix

Wrap the client instantiation in a `try/except AttributeError` so it falls back gracefully to the paho-mqtt 1.x API:

```python
try:
    client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, client_id)
except AttributeError:
    # paho-mqtt < 2.0 does not have CallbackAPIVersion
    client = mqtt.Client(client_id)
```

## Testing

Verified fix on a live HA instance with a cached Docker layer running paho-mqtt 1.6.1 — addon now starts cleanly and streams car data correctly.